### PR TITLE
Toolbox Template Example

### DIFF
--- a/BIO_Toolbox-template/01_Physical_Photo_attacks/01-01_attack.adoc
+++ b/BIO_Toolbox-template/01_Physical_Photo_attacks/01-01_attack.adoc
@@ -1,0 +1,69 @@
+== Number
+
+Eye 1-1
+
+== Attack type
+Eye, printed photo attack
+
+==== Total Number of Species
+This attack has *2* species to be tested.
+
+== Overview
+_In this attack, user’s face digital image is not available but photo of the target can be used to create PAI._
+
+== Input
+
+Photo of target user that meet the following conditions::
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same environment to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+
+* T.1a, type 2
+* T.2, type 1
+* T.3, type 1
+* T.4, type 2
+* M.1, type 2
+
+
+== Recipe
+
+. Attacker scans user’s photo image and saves it in his PC. Resolution of scanner (dpi) should be, for example, 300-600 dpi that achieves best quality of image.
+. Attacker crops the face image using basic image editing software (e.g. Microsoft Paint) to enlarge it to cover as much of the paper as possible while maintaining the original image aspect ratio. If multiple options are available for enlarging the image, an option that achieves best image quality should be selected. Attacker doesn’t use image editing software to enhance quality of face image (such attack is considered later).
+. Attacker prints it out on photo paper. Printer resolution should be, for example, 600 dpi that achieves best quality of image (set to photo print).
+
+== Variations
+
+=== Variation 1
+_This variant uses different printer and paper for the same test._
+
+Tools and Materials changes::
+* T.3, type 2
+* M.1, type 1
+
+Recipe changes::
+* The attacker prints at 600 dpi (or higher) to achieve the best quality print.
+
+== Prerequisite
+
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+During scanning, enlarging and copying the image, lots of information like high frequency information of original eye will be lost. Such changes can be detected by, for example, LBP that require relatively low computational power.
+
+== Reference
+There is no research paper that conduct attacks following this scenario. All PAIs were created using live image of target user, not photo image of the user in all researches.
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+All unlock attempts shall be rejected. Proposed algorithms in the existing research papers are capable to detect this primitive attack.
+

--- a/BIO_Toolbox-template/01_Physical_Photo_attacks/01_02_attack.adoc
+++ b/BIO_Toolbox-template/01_Physical_Photo_attacks/01_02_attack.adoc
@@ -1,0 +1,57 @@
+== Number
+Eye 1-2
+
+== Attack type
+Eye, printed photo attack with contact lens
+
+==== Total Number of Species
+This attack has *1* species to be tested.
+
+== Overview
+_In this attack, user’s face digital image is not available but photo of the target can be used to create PAI._
+
+== Input
+Photo of target user that meet the following conditions::
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same environment to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+
+* T.1a, type 2
+* T.2, type 1
+* T.3, type 2
+* T.4, type 2
+* M.1, type 1
+* M.2, type 1
+
+
+== Recipe
+. Attacker scans user’s photo image and saves it in his PC. Resolution of scanner (dpi) should be, for example, 300-600 dpi that achieves best quality of image.
+. Attacker crops the face image using basic image editing software (e.g. Microsoft Paint) to enlarge it to cover as much of the paper as possible while maintaining the original image aspect ratio. If multiple options are available for enlarging the image, an option that achieves best image quality should be selected. Attacker doesn’t use image editing software to enhance quality of face image (such attack is considered later).
+. Attacker prints it out on photo paper. Printer resolution should be, for example, 600 dpi that achieves best quality of image (set to photo print). Printed photo should have iris size equal to normal iris size.
+. Contact lens is placed on top of iris on photo (place a lens over each visible iris).
+
+== Variations
+None
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo with contact lens attached to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+During scanning, enlarging and copying the image, lots of information like high frequency information of original eye will be lost. Such changes can be detected by, for example, LBP that require relatively low computational power.
+
+== Reference
+There is no research paper that conduct attacks following this scenario. All PAIs were created using live image of target user, not photo image of the user in all researches.
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+All unlock attempts shall be rejected. Proposed algorithms in the existing research papers are capable to detect this primitive attack.

--- a/BIO_Toolbox-template/01_Physical_Photo_attacks/01_03_attack.adoc
+++ b/BIO_Toolbox-template/01_Physical_Photo_attacks/01_03_attack.adoc
@@ -1,0 +1,52 @@
+== Number
+Eye 1-3
+
+== Attack type
+Eye, digital photo attack
+
+==== Total Number of Species
+This attack has *1* species to be tested.
+
+== Overview
+_This attack scenario changes the spoofing medium from the paper to the screen._
+
+== Input
+Photo of target user that meet the following conditions::
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same environment to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 2
+* T.2, type 1
+* T.4, type 2
+* T.5, type 2
+
+== Recipe
+. Attacker scans user’s photo image and saves it in his PC. Resolution of scanner (dpi) should be, for example, 300-600 dpi that achieves best quality of image.
+. Attacker crops the face image using basic image editing software (e.g. Microsoft Paint) to enlarge it to cover as much of the paper as possible while maintaining the original image aspect ratio. If multiple options are available for enlarging the image, an option that achieves best image quality should be selected. Attacker doesn’t use image editing software to enhance quality of face image (such attack is considered later).
+. Attacker displays it on the screen.
+
+== Variations
+None
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the mobile device to the screen by hand at controlled environment. Attacker adjusts the distance between the screen and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the bezels of screen. Attacker also presents the screen to minimize the reflection from ambient lighting.
+
+== PAD technique
+During scanning, enlarging and copying the image, lots of information like high frequency information of original eye will be lost. Such changes can be detected by, for example, LBP that require relatively low computational power.
+
+== Reference
+There is no research paper that conduct attacks following this scenario. All PAIs were created using live image of target user, not photo image of the user in all researches.
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+All unlock attempts shall be rejected. Proposed algorithms in the existing research papers are capable to detect this primitive attack.

--- a/BIO_Toolbox-template/02_Selfie_Image_attacks/02-01_attack.adoc
+++ b/BIO_Toolbox-template/02_Selfie_Image_attacks/02-01_attack.adoc
@@ -1,0 +1,59 @@
+== Number
+Eye 2-1
+
+== Attack type
+Eye, printed photo attack
+
+==== Total Number of Species
+This attack has *2* species to be tested.
+
+== Overview
+_In this attack, normal quality of target user’s digital face image is available to attacker._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least equal to the front-facing camera of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 1
+* T.3, type 1
+* T.4, type 2
+* M.1, type 2
+
+== Recipe
+. Attacker prints it out on photo paper. Printer resolution should be, for example, 600 dpi that achieves best quality of image (set to photo print).
+
+== Variations
+=== Variation 1
+_This variant uses different printer and paper for the same test._
+
+Tools and Materials changes::
+* T.3, type 2
+* M.1, type 1
+
+Recipe changes::
+* The attacker prints at 600 dpi (or higher) to achieve the best quality print.
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the image that can be detected by the PAD. [Patel et al., 2015] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+All unlock attempts shall be rejected. Proposed algorithms in the existing research papers are capable to detect this primitive attack.

--- a/BIO_Toolbox-template/02_Selfie_Image_attacks/02-02_attack.adoc
+++ b/BIO_Toolbox-template/02_Selfie_Image_attacks/02-02_attack.adoc
@@ -1,0 +1,53 @@
+== Number
+Eye 2-2
+
+== Attack type
+Eye, printed photo attack with contact lens
+
+==== Total Number of Species
+This attack has *1* species to be tested.
+
+== Overview
+_This attack scenario changes how to present the PAI and add a contact lens to adjust how the image is presented to the sensor._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least equal to the front-facing camera of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 1
+* T.3, type 1
+* T.4, type 2
+* M.1, type 2
+* M.2, type 1
+
+== Recipe
+. Attacker prints target user’s face image on photo paper using the printer.
+. Contact lens is placed on top of iris on photo (place a lens over each visible iris).
+
+== Variations
+None
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo with contact lens attached to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the image that can be detected by the PAD. [Patel et al., 2015] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/02_Selfie_Image_attacks/02-03_attack.adoc
+++ b/BIO_Toolbox-template/02_Selfie_Image_attacks/02-03_attack.adoc
@@ -1,0 +1,53 @@
+== Number
+Eye 2-3
+
+== Attack type
+Eye, digital photo attack
+
+==== Total Number of Species
+This attack has *1* species to be tested.
+
+== Overview
+_This attack scenario changes the spoofing medium from the paper to the screen._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least equal to the front-facing camera of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 1
+* T.4, type 2
+* T.5, type 2
+
+== Recipe
+. Attacker downloads user’s photo image and saves it in his PC.
+. Attacker crops the face image using basic image editing software (e.g. Microsoft Paint) to enlarge it to cover as much of the screen as possible while maintaining the original image aspect ratio. If multiple options are available for enlarging the image, an option that achieve best image quality should be selected. Attacker doesn’t use image editing software (e.g. Photoshop) to enhance quality of face image (such attack is considered later)
+. Attacker displays it on the screen.
+
+== Variations
+None
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the mobile device to the screen by hand at controlled environment. Attacker adjusts the distance between the screen and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the bezels of screen. Attacker also presents the screen to minimize the reflection
+from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the image that can be detected by the PAD. [Patel et al., 2015] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/02_Selfie_Image_attacks/02-04_attack.adoc
+++ b/BIO_Toolbox-template/02_Selfie_Image_attacks/02-04_attack.adoc
@@ -1,0 +1,54 @@
+== Number
+Eye 2-4
+
+== Attack type
+Eye, digital photo attack
+
+==== Total Number of Species
+This attack has *1* species to be tested.
+
+== Overview
+_Attacker uses image editing software (e.g. Photoshop) to enhance the image quality to create PAI and repeat the attack scenario No. 2-1, 2-2 and 2-3._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least equal to the front-facing camera of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s face occupies about 20% of the full image
+* photo includes user’s full face
+
+== Tools
+* T.5, type 2
+
+== Recipe
+. Attacker downloads user’s photo image and saves it in his PC
+. Attacker crops the face image using image editing software to enlarge it to cover as much of the paper or screen as possible while maintaining the original image aspect ratio. If multiple options are available for enlarging the image, an option that achieve best image quality should be selected.
+. Attacker use image editing software (e.g. Photoshop) to enhance quality of face image. Especially evaluator can try to remove the artefacts such as moiré pattern with such software.
+. Attacker displays it on the paper or screen.
+
+== Variations
+None
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual (i.e. target user should not wear glasses, hat, beard, or heavy make-up during the enrollment if the guidance instructs not to do so) under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the mobile device to the screen by hand at controlled environment. Attacker adjusts the distance between thescreen and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the bezels of screen. Attacker also presents the screen to minimize the reflection
+from ambient lighting.
+
+== PAD technique
+None of research paper studies this scenario.
+
+However, image editing software can be purchased at low cost.
+
+== Reference
+None
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-01_attack.adoc
+++ b/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-01_attack.adoc
@@ -1,0 +1,73 @@
+== Number
+Eye 3-1
+
+== Attack type
+Eye, printed photo attack
+
+==== Total Number of Species
+This attack has *3* species to be tested.
+
+== Overview
+_This scenario is same as No. 2-1 except normal quality of user’s image and spoofing medium are used instead of the low quality ones._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least double the resolution of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 2
+* T.3, type 1
+* T.4, type 2
+* M.1, type 2
+
+== Recipe
+. Attacker prints it out on photo paper. Printer resolution should be, for example, 600 dpi that achieves best quality of image (set to photo print).
+
+== Variations
+=== Variation 1
+_This variant uses different printer and paper for the same test._
+
+Tools and Materials changes::
+* T.3, type 2
+* M.1, type 1
+
+Recipe changes::
+* The attacker prints at 600 dpi (or higher) to achieve the best quality print.
+
+=== Variation 2
+_This variant uses the camera in a night mode to attempt to acquire an IR/NIR image of the iris. Only the laser printer is used as the image is not in the full visible spectrum (if any), so a high-quality laser print is sufficient._
+
+Input changes::
+* Unless the camera can operate in a night mode while in a fully-lit room, the conditions of the room must be adjusted to provide a better likelihood of using the IR/NIR range of the camera (i.e. low light).
+
+Tools and Materials changes::
+* T.1b, type 2
+* T.3, type 2
+* M.1, type 1
+
+Recipe changes::
+* The attacker prints at 600 dpi (or higher) to achieve the best quality print.
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the image that can be detected by the PAD. [Patel et al., 2015] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-02_attack.adoc
+++ b/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-02_attack.adoc
@@ -1,0 +1,66 @@
+== Number
+Eye 3-2
+
+== Attack type
+Eye, printed photo attack with contact lens
+
+==== Total Number of Species
+This attack has *2* species to be tested.
+
+== Overview
+_This attack scenario changes how to present the PAI and add a contact lens to adjust how the image is presented to the sensor._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least double the resolution of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+=  Tools
+* T.1a, type 2
+* T.3, type 1
+* T.4, type 2
+* M.1, type 2
+* M.2, type 1
+
+== Recipe
+. Attacker prints target user’s face image on photo paper using the printer.
+. Contact lens is placed on top of iris on photo (place a lens over each visible iris).
+
+
+== Variations
+=== Variation 1
+_This variant uses the camera in a night mode to attempt to acquire an IR/NIR image of the iris. Only the laser printer is used as the image is not in the full visible spectrum (if any), so a high-quality laser print is sufficient._
+
+Input changes::
+* Unless the camera can operate in a night mode while in a fully-lit room, the conditions of the room must be adjusted to provide a better likelihood of using the IR/NIR range of the camera (i.e. low light).
+
+Tools and Materials changes::
+* T.1b, type 2
+* T.3, type 2
+* M.1, type 1
+
+Recipe changes::
+* The attacker prints at 600 dpi (or higher) to achieve the best quality print.
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo with contact lens attached to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the image that can be detected by the PAD. [Patel et al., 2015] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-03_attack.adoc
+++ b/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-03_attack.adoc
@@ -1,0 +1,61 @@
+== Number
+Eye 3-3
+
+== Attack type
+Eye, digital photo attack
+
+==== Total Number of Species
+This attack has *2* species to be tested.
+
+== Overview
+_This attack scenario changes the spoofing medium from the paper to the screen._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least double the resolution of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 2
+* T.4, type 2
+* T.5, type 2
+
+=  Recipe
+. Attacker downloads user’s photo image and saves it in his PC.
+. Attacker crops the face image using basic image editing software (e.g. Microsoft Paint) to enlarge it to cover as much of the screen as possible while maintaining the original image aspect ratio. If multiple options are available for enlarging the image, an option that achieve best image quality should be selected. Attacker doesn’t use image editing software (e.g. Photoshop) to enhance quality of face image (such attack is considered later)
+. Attacker displays it on the screen.
+
+== Variations
+=== Variation 1
+_This variant uses the camera in a night mode to attempt to acquire an IR/NIR image of the iris._
+
+Input changes::
+* Unless the camera can operate in a night mode while in a fully-lit room, the conditions of the room must be adjusted to provide a better likelihood of using the IR/NIR range of the camera (i.e. low light).
+
+Tools and Materials changes::
+* T.1b, type 2
+
+== Prerequisite
+
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the mobile device to the screen by hand at controlled environment. Attacker adjusts the distance between the screen and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the bezels of screen. Attacker also presents the screen to minimize the reflection
+from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the image that can be detected by the PAD. [Patel et al., 2015] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-04_attack.adoc
+++ b/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-04_attack.adoc
@@ -1,0 +1,49 @@
+== Number
+Eye 3-4
+
+== Attack type
+Eye, printed photo attack
+
+==== Total Number of Species
+This attack has *1* species to be tested.
+
+== Overview
+_This scenario is same as No. 3-1 except normal quality of user’s image is used with professional photo printing are used instead of the low quality ones._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least double the resolution of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 2
+* T.3, type 3
+
+== Recipe
+. Attacker has photo printed at professional printing service.
+
+== Variations
+None
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the image that can be detected by the PAD. [Patel et al., 2015] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-05_attack.adoc
+++ b/BIO_Toolbox-template/03_Mobile_Camera_attacks/03-05_attack.adoc
@@ -1,0 +1,55 @@
+== Number
+Eye 3-5
+
+== Attack type
+Eye, digital photo attack
+
+==== Total Number of Species
+This attack has *1* species to be tested.
+
+== Overview
+_Attacker uses image editing software (e.g. Photoshop) to enhance the image quality to create PAI and repeat the attack scenario No. 3-1, 3-2 and 3-3._
+
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least equal to the front-facing camera of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s face occupies about 20% of the full image
+* photo includes user’s full face
+
+== Tools
+* T.5, type 2
+
+== Recipe
+. Attacker downloads user’s photo image and saves it in his PC
+. Attacker crops the face image using image editing software to enlarge it to cover as much of the paper or screen as possible while maintaining the original image aspect ratio. If multiple options are available for enlarging the image, an option that achieve best image quality should be selected.
+. Attacker use image editing software (e.g. Photoshop) to enhance quality of face image. Especially evaluator can try to remove the artefacts such as moiré pattern with such software.
+. Attacker displays it on the paper or screen.
+
+== Variations
+None
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual (i.e. target user should not wear glasses, hat, beard, or heavy make-up during the enrollment if the guidance instructs not to do so) under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the mobile device to the screen by hand at controlled environment. Attacker adjusts the distance between thescreen and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the bezels of screen. Attacker also presents the screen to minimize the reflection
+from ambient lighting.
+
+== PAD technique
+None of research paper studies this scenario.
+
+However, image editing software can be purchased at low cost.
+
+== Reference
+None
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/04_DSLR_Camera_attacks/04-01_attack.adoc
+++ b/BIO_Toolbox-template/04_DSLR_Camera_attacks/04-01_attack.adoc
@@ -1,0 +1,73 @@
+== Number
+Eye 4-1
+
+== Attack type
+Eye, printed photo attack
+
+==== Total Number of Species
+This attack has *3* species to be tested.
+
+== Overview
+_This scenario is same as No. 2-1 except high quality of user’s image and spoofing medium are used instead of the normal quality ones._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the DSR camera whose resolution is 40MP and above.
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 3
+* T.3, type 1
+* T.4, type 2
+* M.1, type 2
+
+== Recipe
+. Attacker prints it out on photo paper. Printer resolution should be, for example, 600 dpi that achieves best quality of image (set to photo print).
+
+== Variations
+=== Variation 1
+_This variant uses different printer and paper for the same test._
+
+Tools and Materials changes::
+* T.3, type 2
+* M.1, type 1
+
+Recipe changes::
+* The attacker prints at 600 dpi (or higher) to achieve the best quality print.
+
+=== Variation 2
+_This variant uses the camera in a night mode to attempt to acquire an IR/NIR image of the iris. Only the laser printer is used as the image is not in the full visible spectrum (if any), so a high-quality laser print is sufficient._
+
+Input changes::
+* Unless the camera can operate in a night mode while in a fully-lit room, the conditions of the room must be adjusted to provide a better likelihood of using the IR/NIR range of the camera (i.e. low light).
+
+Tools and Materials changes::
+* T.1b, type 3
+* T.3, type 2
+* M.1, type 1
+
+Recipe changes::
+* The attacker prints at 600 dpi (or higher) to achieve the best quality print.
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Depth sensor can be used to detect 2D object. ???
+
+== Reference
+For example, see [Bhattacharjee & Marcel, 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/04_DSLR_Camera_attacks/04-02_attack.adoc
+++ b/BIO_Toolbox-template/04_DSLR_Camera_attacks/04-02_attack.adoc
@@ -1,0 +1,64 @@
+== Number
+Eye 4-2
+
+== Attack type
+Eye, printed photo attack
+
+==== Total Number of Species
+This attack has *2* species to be tested.
+
+== Overview
+_Same as No.2-2 except high quality of user’s image is used instead of the normal quality_
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the DSR camera whose resolution is 40MP and above.
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 3
+* T.3, type 1
+* T.4, type 2
+* M.1, type 2
+* M.2, type 1
+
+== Recipe
+. Attacker prints target user’s face image on photo paper using the printer.
+. Contact lens is placed on top of iris on photo (place a lens over each visible iris).
+
+== Variations
+=== Variation 1
+_This variant uses different printer and paper for the same test._
+
+Input changes::
+* Unless the camera can operate in a night mode while in a fully-lit room, the conditions of the room must be adjusted to provide a better likelihood of using the IR/NIR range of the camera (i.e. low light).
+
+Tools and Materials changes::
+* T.1b, type 3
+* M.1, type 1
+
+Recipe changes::
+* The attacker prints at 600 dpi (or higher) to achieve the best quality print.
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo with contact lens attached to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Depth sensor can be used to detect 2D object. ???
+
+== Reference
+For example, see [Bhattacharjee & Marcel, 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/04_DSLR_Camera_attacks/04-03_attack.adoc
+++ b/BIO_Toolbox-template/04_DSLR_Camera_attacks/04-03_attack.adoc
@@ -1,0 +1,59 @@
+== Number
+Eye 4-3
+
+== Attack type
+Eye, digital photo attack
+
+==== Total Number of Species
+This attack has *2* species to be tested.
+
+== Overview
+_This attack scenario changes the spoofing medium from the paper to the screen._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the DSR camera whose resolution is 40MP and above.
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 3
+* T.4, type 2
+* T.5, type 2
+
+== Recipe
+. Attacker downloads user’s photo image and saves it in his PC.
+. Attacker crops the face image using basic image editing software (e.g. Microsoft Paint) to enlarge it to cover as much of the screen as possible while maintaining the original image aspect ratio. If multiple options are available for enlarging the image, an option that achieve best image quality should be selected. Attacker doesn’t use image editing software (e.g. Photoshop) to enhance quality of face image (such attack is considered later)
+. Attacker displays it on the screen.
+
+== Variations
+=== Variation 1
+_This variant uses the camera in a night mode to attempt to acquire an IR/NIR image of the iris._
+
+Input changes::
+* Unless the camera can operate in a night mode while in a fully-lit room, the conditions of the room must be adjusted to provide a better likelihood of using the IR/NIR range of the camera (i.e. low light).
+
+Tools and Materials changes::
+* T.1b, type 3
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s iris following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for face unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Depth sensor can be used to detect 2D object. ???
+
+== Reference
+For example, see [Bhattacharjee & Marcel, 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/04_DSLR_Camera_attacks/04-04_attack.adoc
+++ b/BIO_Toolbox-template/04_DSLR_Camera_attacks/04-04_attack.adoc
@@ -1,0 +1,49 @@
+== Number
+Eye 4-4
+
+== Attack type
+Eye, printed photo attack
+
+==== Total Number of Species
+This attack has *1* species to be tested.
+
+== Overview
+_This scenario is same as No. 2-1 except normal quality of user’s image is used with professional photo printing are used instead of the low quality ones._
+
+== Input
+Digital image of target user that meet the following conditions::
+* captured by the mobile device camera whose resolution is at least double the resolution of the device to be tested (or to use a second device of the same model). Evaluator shall not use the specific mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* photo was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* photo was taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is rejected because of the difference of the background scene or expression
+* target user’s eyes are open and iris is mostly visible (i.e. well lit room)
+* photo includes user’s full face
+
+== Tools
+* T.1a, type 3
+* T.3, type 3
+
+== Recipe
+. Attacker has photo printed at professional printing service.
+
+== Variations
+None
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker presents the photo to the device by hand at controlled environment. Attacker adjusts the distance between the photo and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the edge of photo. Attacker also presents the photo to minimize the reflection from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the image that can be detected by the PAD. [Patel et al., 2015] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/05_Mobile_Video_attacks/05-01_attack.adoc
+++ b/BIO_Toolbox-template/05_Mobile_Video_attacks/05-01_attack.adoc
@@ -1,0 +1,58 @@
+== Number
+Eye 5-1
+
+== Attack type
+Eye, replay video attack
+
+==== Total Number of Species
+This attack has *2* species to be tested.
+
+== Overview
+_In this attack, normal quality of target user’s video is available to attacker._
+
+== Input
+Digital video of target user’s face that meet the following conditions::
+* recorded by the mobile device camera at full HD resolution. Evaluator shall not use the mobile device that embeds the TOE (because the TOE may be trained using images captured by the mobile device)
+* video was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* video is taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is falsely rejected because of the difference of the background scene or expression
+* video includes user’s full face
+* target user’s eyes are open and iris is mostly visible (natural blinking is acceptable)
+* the video length is limited to 10 seconds
+
+== Tools
+* T.1a, type 2
+* T.5
+
+== Recipe
+. Attacker displays target user’s face video on the screen.
+
+== Variations
+=== Variation 1
+_This variant uses the camera in a night mode to attempt to acquire an IR/NIR video image of the iris._
+
+Tools and Materials changes::
+* T.1b, type 2
+* T.5
+
+Recipe changes::
+* Unless the camera can operate in a night mode while in a fully-lit room, the conditions of the room must be adjusted to provide a better likelihood of using the IR/NIR range of the camera (i.e. low light).
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker fixes the mobile device and screen at controlled environment. Attacker adjusts the distance between the screen and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the bezels of screen. Attacker also presents the screen to minimize the reflection from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the video that can be detected by the PAD. [4] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/06_DSLR_Video_attacks/06-01_attack.adoc
+++ b/BIO_Toolbox-template/06_DSLR_Video_attacks/06-01_attack.adoc
@@ -1,0 +1,58 @@
+== Number
+Eye 6-1
+
+== Attack type
+Eye, replay video attack
+
+==== Total Number of Species
+This attack has *2* species to be tested.
+
+== Overview
+_In this attack, high quality of target user’s video is available to attacker._
+
+== Input
+Digital video of target user’s face that meet the following conditions::
+* recorded by the camera at higher than full HD resolution.
+* video was taken under controlled environment where the background of the scene is uniform, the light in the office is switched on and the window blinds are down
+* video is taken right after the target user’s enrolment and under the same condition to reduce the possibility that the PAI is falsely rejected because of the difference of the background scene or expression
+* video includes user’s full face
+* target user’s eyes are open and iris is mostly visible (natural blinking is acceptable)
+* the video length is limited to 10 seconds
+
+== Tools
+* T.1b, type 3
+* T.5
+
+== Recipe
+. Attacker displays target user’s face video on the screen.
+
+== Variations
+=== Variation 1
+_This variant uses the camera in a night mode to attempt to acquire an IR/NIR video image of the iris._
+
+Tools and Materials changes::
+* T.1b, type 3
+* T.5
+
+Recipe changes::
+* Unless the camera can operate in a night mode while in a fully-lit room, the conditions of the room must be adjusted to provide a better likelihood of using the IR/NIR range of the camera (i.e. low light).
+
+== Prerequisite
+Target user turns on the eye unlock and registers user’s eye following instructions provided by the device and manual under the controlled environment.
+
+If the ST covers the multiple configurations for eye unlock, the same test should be done for all configurations.
+
+== Presentation
+Attacker fixes the mobile device and screen at controlled environment. Attacker adjusts the distance between the screen and the device seeing relevant attack video clip or attacker adjusts to right distance so that the device camera can’t see the bezels of screen. Attacker also presents the screen to minimize the reflection from ambient lighting.
+
+== PAD technique
+Different types of image aliasing appear during the recapture of the video that can be detected by the PAD. [4] study the PAD method that can be implemented on the mobile device.
+
+== Reference
+For example, see [Zhang et al., 2012], [Patel et al., 2015] and [Boulkenafet et al., 2017]
+
+== Attack Potential
+tbd
+
+== Pass Criteria
+tbd

--- a/BIO_Toolbox-template/BIO_PAD_Testing.adoc
+++ b/BIO_Toolbox-template/BIO_PAD_Testing.adoc
@@ -1,0 +1,66 @@
+= Mobile Toolbox for Eye Verification for FIA_MBV_EXT.3
+:showtitle:
+:sectnums:
+:revdate: 2019-03-01
+
+== Evaluation Activity and Penetration testing for Eye PAD
+The eye PAD testing is based on the 2D Image-based PAD methodology.
+
+== Eye-specific Changes to the Methodology
+=== Background
+There are two general categories of eye scanners on the market today, divided by the wavelength of light used to take the image of the iris. It is expected that a sensor uses one or the other, but not both types of light when taking the image of the iris (though using both is not a barrier to testing). While there are also scanners that use the retina instead of the iris, this is not known to be used on mobile devices at this point.
+
+To handle this situation, additional tools and materials are added to the eye inventory.
+
+=== Additional Tools
+To handle potential eye sensors that rely on near-Infrared (NIR) or Infrared (IR) requires the use of a camera that can take pictures using these wavelengths. Some mobile devices may support this as a low-light mode. There are cameras on the market which explicitly support night modes that can take images using the proper wavelengths for these types of sensors.
+
+=== Additional Materials
+It has been shown that having a lens to help curve the image can assist in bypassing an iris match from a flat image _[see Chaos Computer Club, 2017]_. To handle this type of attack, contact lenses are added to the materials list.
+
+=== Camera Selection
+The Evaluator shall determine which sets of camera tests to run based on what is known about the sensor being used. Sensors that do not use IR or NIR do not need to have tests run using cameras with capabilities to capture such images.
+
+For IR or NIR sensors, all pictures must be taken in a night mode. For mobile device images this means taking the picture in low light (which may not be the best given the smallest amount of iris will be shown, so that must be balanced by the Evaluator). For the camera with a night mode, this must be activated, preferably even during daylight to get the best results.
+
+== Image Recommendations for Level 3
+Based on earlier work _[see Chaos Computer Club, 2015]_ for Level 3 tests the Evaluator should attempt to acquire Images where the iris diameter is at least 75 pixels and the printout should have an equivalent of 1200 DPI.
+
+Note that when tests require the use of the contact lenses, the printed image of the iris must batch the diameter of the contact lens for proper overlay.
+
+== Attack categories
+There are several categories of attacks based on the source of the image/video being used to create the PAI.
+
+.Categories
+[%header,cols="1,3,6"]
+|===
+| No.
+| Source
+| Description
+
+| 1
+| Physical Source
+| The target does not post pictures on SNS/internet or is very limited in distribution. A physical picture is found (such as on a desk) and is scanned as the source for the PAI.
+
+| 2
+| Selfie Image
+| The target has taken a selfie picture and uploaded it to SNS/internet where it can be readily found and used as the basis of the PAI.
+
+| 3
+| Mobile Device Camera Image
+| The target has taken a picture using the main Mobile Device camera and uploaded it to SNS/internet where it can be readily found and used as the basis of the PAI.
+
+| 4
+| High Quality Camera Image
+| The target has a high quality facial picture uploaded to SNS/internet where it can be readily found and used as the basis of the PAI.
+
+| 5
+| Mobile Device Video
+| The target has a low quality (i.e. mobile device quality) video of their face taken and posted to SNS/internet where it can be readily found and used as the basis of the PAI.
+
+| 6
+| High Quality Video
+| The target has a high quality (i.e. dSLR or other high quality video recording) video of their face taken and posted to SNS/internet where it can be readily found and used as the basis of the PAI.
+|===
+
+These attack categories are used as the basis for determining the source for the PAI and how an attack can be attempted.

--- a/BIO_Toolbox-template/BIO_inventory.adoc
+++ b/BIO_Toolbox-template/BIO_inventory.adoc
@@ -1,0 +1,74 @@
+= Eye Toolbox Inventory
+This document contains the inventory of tools and materials that are used in the context of the toolbox.
+
+.Tools
+[%header,cols=5*]
+|===
+| ID
+| Category
+| Type 1
+| Type 2
+| Type 3
+
+
+| T.1a
+| Camera
+| Front-facing device camera
+| Digital Camera (min resolution = 2 * device resolution)
+| DSR 40+ MP
+
+| T.1b
+| Night-mode camera
+| Front-facing device camera
+| Digital Camera (min resolution = 2 * device resolution)
+| Camera with explicit night mode
+
+| T.2
+| Scanner
+| 1200 DPI
+|  
+| Professional
+
+| T.3
+| Printer
+| Home SoHo Inkjet
+| Color Laser  (Resolution 600+ DPI)
+| Printing Service
+
+| T.4
+| Computing resources
+| Mobile device
+| PC or laptop
+| Professional
+
+| T.5
+| Output Screen
+| 1080p 10"
+| 1080p -> 2160p under 20"
+| 4K above 24"
+|===
+
+
+.Materials
+[%header,cols=5*]
+|===
+
+| ID
+| Category
+| Type 1
+| Type 2 
+| Type 3
+
+
+| M.1
+| Paper
+| Standard office paper  (Paper weight would impact print quality (for example in the US paper is usually 20lb or 24lb in office use with the higher one being better quality and hence probably better for generating a PAI))
+|   Glossy photo paper
+| N/A
+
+| M.2
+| Contact Lens
+| Standard, non-colored contact lens with low prescription
+|
+|
+|===

--- a/BIO_Toolbox-template/BIO_list.adoc
+++ b/BIO_Toolbox-template/BIO_list.adoc
@@ -1,0 +1,161 @@
+= Mobile Toolbox for Eye Verification List
+:showtitle:
+:revdate: 2019-05-03
+
+This shows the set of attacks and applicability based on the sensor type used for Eye modalities.
+
+.Categories
+[%header,cols="2,4,1,1"]
+|===
+|No.
+|Name
+|Near IR
+|IR
+
+
+|Eye 1-1
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 1-1 (V1)
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 1-2
+|Eye, printed photo attack with contact lens
+|X
+|X
+
+|Eye 1-3
+|Eye, digital photo attack
+|X
+|
+
+|Eye 2-1
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 2-1 (V1)
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 2-2
+|Eye, printed photo attack with contact lens
+|X
+|X
+
+|Eye 2-3
+|Eye, digital photo attack
+|X
+|
+
+|Eye 2-4
+|Eye, digital photo attack
+|X
+|
+
+|Eye 3-1
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 3-1 (V1)
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 3-1 (V2)
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 3-2
+|Eye, printed photo attack with contact lens
+|X
+|X
+
+|Eye 3-2 (V1)
+|Eye, printed photo attack with contact lens
+|X
+|X
+
+|Eye 3-3
+|Eye, digital photo attack
+|X
+|
+
+|Eye 3-3 (V1)
+|Eye, digital photo attack
+|X
+|
+
+|Eye 3-4
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 3-5
+|Eye, digital photo attack
+|X
+|
+
+|Eye 4-1
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 4-1 (V1)
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 4-1 (V2)
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 4-2
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 4-2 (V1)
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 4-3
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 4-3 (V1)
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 4-4
+|Eye, printed photo attack
+|X
+|X
+
+|Eye 5-1
+|Eye, replay video attack
+|X
+|
+
+|Eye 6-1
+|Eye, replay video attack
+|X
+|
+
+|Eye 6-1
+|Eye, replay video attack
+|X
+|
+
+|===

--- a/BIO_Toolbox-template/BIO_references.adoc
+++ b/BIO_Toolbox-template/BIO_references.adoc
@@ -1,0 +1,13 @@
+== References
+
+[1] [Chaos Computer Club, 2017] Hacking the Samsung Galaxy S8 Irisscanner
+
+https://media.ccc.de/v/biometrie-s8-iris-en
+
+https://www.theverge.com/circuitbreaker/2017/5/23/15680268/hacker-galaxy-s8-iris-scanner-ir-image-contact-lens-starbug
+
+[2] [Chaos Computer Club, 2015] Hacker Finds a Simple Way to Fool IRIS Biometric Security Systems
+
+https://thehackernews.com/2015/03/iris-biometric-security-bypass.html
+
+https://www.forbes.com/sites/thomasbrewster/2015/03/05/clone-putins-eyes-using-google-images


### PR DESCRIPTION
This is in response to #18 about related to having a standardized template for a toolbox.

There are 4 files in the main folder (here BIO is used to mark the modality, so this should be EYE, FACE, FINGER, etc):

PAD Testing - the description of anything specific to this modality that needs to be documented (in addition to the toolbox overview) along with an introduction to the toolbox.

List - a table list of all the tests and any applicability notes (like these are only relevant with certain types of sensors or other considerations)

Inventory - a list of the inventory that is used in the test, things like paper, printers, camera, the things used to make the PAI

References - external references for any of the attacks (a master list)

Within the main folder there would then be subfoldlers marked with XX_<attack category>_attacks. The XX would be numbering for increasing difficulty (i.e. the lowest level PAI, simplest to create would be 01, the most difficult test would be the top number). The <attack category> would be some sort of title that would provide some clarity as to what the tests will be used as a source for the PAI.

Within each folder then, you would have the files names XX_YY_attack where the XX matches the folder number and YY is the test number.

The List table should match out all the numbers. While I don't have it in here, there is a (Vx) listing for some of the tests, this is when there is a number of variants for the specific test available (so a test with a V1 and V2 would have 2 variants in addition to the "base" test). This could be handled in another way though.

This used the eye tests to fill out the template, but I didn't modify any of the files.