### PR TITLE
Adding the modality versioning

### DIFF
--- a/toolbox.adoc
+++ b/toolbox.adoc
@@ -93,6 +93,35 @@ Each test item includes the following sub-sections. This toolbox overview provid
 
 |===
 
+== Finding and accessing the Toolboxes
+To provide flexibility in support for testing the various biometric modalities for PAD, the versioning of the Toolboxes are maintained independently from the versioning of the primary documents (<<BIOPP-Module>> and <<BIOSD>>). Each Toolbox is maintained separately within its own GitHub repository so updates targeted to specific modalities can be updated independently as needed over time.
+
+There are several ways to find the Toolboxes that are available. 
+
+The simplest method is to go to the GitHub Public Release Packages table from the https://biometricitc.github.io/#_current_published_documents[Biometrics Security iTC homepage]. Each available Toolbox will be listed along with a direct link in GitHub to the most recent toolbox package for that modality.
+
+The second method is to go to the https://github.com/biometricITC[Biometrics Security iTC organization] in GitHub and find the repositories for each modality there. Each modality has a repository titled <Modality>-Toolbox (where <Modality> would be replaced by a supported modality type). From the home page of the repository, on the right side there is a section titled "Releases". Here you will find all the released versions of the particular toolbox.
+
+=== Toolbox versioning
+To keep the versioning simple, each released update is just given a sequential whole number, so 1, 2, 3... (the original release was versioned 1.0, but subsequent updates are following the whole number sequencing). 
+
+=== Toolboxes and technical decisions
+Unlike the primary documents (such as the <<BIOPP-Module>> and <<BIOSD>>), toolboxes are always fully updated to the next revision; there are no Technical Decisions applied to a Toolbox, it is updated, approved and released as a new version (i.e. moved from v2 to v3).
+
+=== Choosing the correct version
+In general it is expected that an evaluation will utilize the most recent version of the Toolbox as of the time the evaluation was started (as defined by the scheme). As the Toolboxes can be updated at any time, the evaluation start date is used to help vendors freeze the requirements for their products.
+
+It is possible for a scheme to have different requirements about what version of a Toolbox should be used, which supercedes any recommendations made by the iTC. 
+
+=== Referencing toolboxes in an evaluation
+As all evaluations must properly reference the Protection Profiles and Supporting Documents, the Toolbox(es) used in an evaluation claiming support for PAD must list the specific versions of any Toolboxes. 
+
+The reference in the Conformance Claims section of the Security Target should provide the following information to unambigiously point to the correct Toolbox as part of the claims for the PP-Configuration (using the Face Toolbox as an example):
+
+Toolbox: Face Toolbox, Version 2, November 11, 2021 (https://github.com/biometricITC/Face-Toolbox/releases/tag/v2)
+
+All components, including the GitHub link to the specific version must be included in the Security Target.
+
 == Common guidance for Independent & Vulnerability Testing
 As explained in <<BIOPP-Module>>, the TOE is the whole biometric system, including Comparison, Decision and Presentation Attack Detection Subsystems. This means in order to successfully overcome the TOE by the use of artefacts, a genuine person (test subject) has to be enroled into the TOE, artefacts have to be created referring the toolbox for the corresponding biometric modality and artefacts have to produce an attack presentation match (i.e. a successful presentation attack).
 


### PR DESCRIPTION
This is to close #378 in the cPP-biometrics.

This adds the documentation in the Toolbox Overview about how to find the toolboxes, how they are versioned, and how to reference them in the conformance claims