### PR TITLE
v1.1 Publication update (#62)

### DIFF
--- a/toolbox.adoc
+++ b/toolbox.adoc
@@ -5,14 +5,14 @@
 :imagesdir: images
 :icons: font
 :revnumber: 1.1
-:revdate: November 9, 2021
+:revdate: September 12, 2022
 :doctype: book
 :xrefstyle: full
 
 == Introduction
 The TOE may be vulnerable to presentation attacks where attackers attempt to subvert the biometric enrolment or verification by presenting the Presentation Attack Instruments (PAIs). There is a wide range of PAIs that can be used, including natural biometric characteristics, such as dead eyes, or artefacts created from copied or faked characteristics. Using natural biometric characteristics is out of scope of <<BIOPP-Module>> evaluation and the evaluator shall only use created artefacts to evaluate the TOE.
 
-The toolbox defines the common artefacts for each biometric modality based on publicly available information (e.g. research papers), experiences and knowledge shared among the BIO-iTC members. The evaluator needs to read the <<BIOSD>> Section 7 as it explains how the evaluator shall use the toolbox during the ATE_IND.1 (Independent testing) and AVA_VAN.1 (Penetration testing) evaluation for Presentation Attack Detection (PAD) in detail.
+The toolbox defines the common artefacts for each biometric modality based on publicly available information (e.g. research papers), experiences and knowledge shared among the BIO-iTC members. The evaluator needs to read the <<BIOSD>> Section 7 as it explains how the evaluator shall use the toolbox during the ATE_IND.1 (Independent testing) and AVA_VAN.1 (Penetration testing) evaluation for Presentation Attack Detection (PAD) in detail. In this evaluation, PAD is being measured using Imposter Attack Presentation Attack Rate (IAPAR), which is a full system review as opposed to a component level review which would evaluate the matching subsystem and PAD subsystem separately.
 
 This overview is originally developed for evaluation activities for FIA_MBV_EXT.3, however, the evaluator can apply the same principles to evaluation activities for FIA_MBE_EXT.3.
 
@@ -93,6 +93,35 @@ Each test item includes the following sub-sections. This toolbox overview provid
 
 |===
 
+== Finding and accessing the Toolboxes
+To provide flexibility in support for testing the various biometric modalities for PAD, the versioning of the Toolboxes are maintained independently from the versioning of the primary documents (<<BIOPP-Module>> and <<BIOSD>>). Each Toolbox is maintained separately within its own GitHub repository so updates targeted to specific modalities can be updated independently as needed over time.
+
+There are several ways to find the Toolboxes that are available. 
+
+The simplest method is to go to the GitHub Public Release Packages table from the https://biometricitc.github.io/#_current_published_documents[Biometrics Security iTC homepage]. Each available Toolbox will be listed along with a direct link in GitHub to the most recent toolbox package for that modality.
+
+The second method is to go to the https://github.com/biometricITC[Biometrics Security iTC organization] in GitHub and find the repositories for each modality there. Each modality has a repository titled <Modality>-Toolbox (where <Modality> would be replaced by a supported modality type). From the home page of the repository, on the right side there is a section titled "Releases". Here you will find all the released versions of the particular toolbox.
+
+=== Toolbox versioning
+To keep the versioning simple, each released update is just given a sequential whole number, so 1, 2, 3... (the original release was versioned 1.0, but subsequent updates are following the whole number sequencing). 
+
+=== Toolboxes and technical decisions
+Unlike the primary documents (such as the <<BIOPP-Module>> and <<BIOSD>>), toolboxes are always fully updated to the next revision; there are no Technical Decisions applied to a Toolbox, it is updated, approved and released as a new version (i.e. moved from v2 to v3).
+
+=== Choosing the correct version
+In general it is expected that an evaluation will utilize the most recent version of the Toolbox as of the time the evaluation was started (as defined by the scheme). As the Toolboxes can be updated at any time, the evaluation start date is used to help vendors freeze the requirements for their products.
+
+It is possible for a scheme to have different requirements about what version of a Toolbox should be used, which supercedes any recommendations made by the iTC. 
+
+=== Referencing toolboxes in an evaluation
+As all evaluations must properly reference the Protection Profiles and Supporting Documents, the Toolbox(es) used in an evaluation claiming support for PAD must list the specific versions of any Toolboxes. 
+
+The reference in the Conformance Claims section of the Security Target should provide the following information to unambigiously point to the correct Toolbox as part of the claims for the PP-Configuration (using the Face Toolbox as an example):
+
+Toolbox: Face Toolbox, Version 2, November 11, 2021 (https://github.com/biometricITC/Face-Toolbox/releases/tag/v2)
+
+All components, including the GitHub link to the specific version must be included in the Security Target.
+
 == Common guidance for Independent & Vulnerability Testing
 As explained in <<BIOPP-Module>>, the TOE is the whole biometric system, including Comparison, Decision and Presentation Attack Detection Subsystems. This means in order to successfully overcome the TOE by the use of artefacts, a genuine person (test subject) has to be enroled into the TOE, artefacts have to be created referring the toolbox for the corresponding biometric modality and artefacts have to produce an attack presentation match (i.e. a successful presentation attack).
 
@@ -120,6 +149,44 @@ Artefact production needs to follow these requirements:
 * The evaluator shall document any necessary information so that artefacts used for the test can be re-produced by the evaluator.
 
 * Each produced artefact shall be identified by a unique identifier. This identifier shall be attached to the artefact at all times (as far as this is possible without destroying the artefact).
+
+As the testing described in the individual toolboxes encompasses the creation and presentation of a large number of artefacts, the test report shall provide sufficient information to ensure how the artefacts were created, presented and as applicable, stored (or retrieved from storage).
+
+If the scheme provides a guidance on the level of detail of the report, the evaluator must follow such guidance. However, if there is no guidance available from the scheme, the BIO-iTC recommends the inclusion of visual (pictures and/or video) evidence in the test report. If sound is included as part of the biometric system, then audio evidence should also be included with the visual evidence.
+
+Broadly, visual/audio evidence should be used on a per-artefact type basis, such that each type is shown clearly once, and the remainder of artefact production and usage would be recorded as expected (but not captured with visual or audio recordings). The evidence collected does not need to be continuous (for example a full video recording of every step), but must record significant steps in the creation of the artefact. 
+
+If visual/audio evidence is being provided, the following categories should have visual/audio evidence:
+
+* Creation of an artefact type (significant steps)
+* Use of an artefact type (preparation that may be needed, usage)
+* If applicable, storage of an artefact type after use
+** How the artefact will be stored for later use
+* If applicable, retrieval of an artefact type from storage for use
+** How is the artefact prepared for use after removed from storage
+
+From a planning standpoint, the easiest way to handle this would be to record one artefact from retrieval/production to disposal/storage (depending on the type).
+
+===== Artefact storage
+It is widely known that, for any biometric modality, some degree of variation in the biometric features will occur over time. For example, the levels of skin dryness is different between summer and winter, and captured fingerprint images from the same person may also vary a little but such little difference may affect the biometric performance. So, fingerprint artefacts created in winter should not be used for presentation attacks against enrolment images captured in summer. The quality of artefacts may also be changed over time. For example, glue used for fingerprint artefacts begins to dry and harden and the success rate of attacks may begin to drop within a few weeks after the creation of the artefacts. 
+
+The evaluator may reuse artefacts for later evaluations, however, the evaluator shall check that the following conditions are met to reuse the stored artefacts:
+
+* Time difference between enrolment and artefact creation and usage should be as minimal as possible, though individual biometric modalities may have different time periods for which reuse is acceptable. If the evaluator uses artefacts older (or for longer) than one month (here defined as a five week period from enrolment and creation), the evalutor shall follow the guidance in <<Use of stored artefacts, Use of stored artefacts>> for proper storage and retrieval of the artefacts.
+* Artefacts should be properly stored according to the manufacturer's recommendations and remain free of visible defects. Some of these may be obvious, like the proper storage of photographs, but others may be more detailed, requiring temperature and humidity controls. For artefacts that are capable of being stored, information about what is done to store the artefacts (supported by visual evidence and documentation) along with guidance from the manufacturer that supports the methods implemented.
+
+===== Use of stored artefacts 
+For artefacts where long term storage of more than one month and re-use is more subjective (such as the fingerprint artefacts), information about how it was determined whether the artefact was in acceptable condition must be provided (for example levels of dryness and hardness).
+
+If artefacts stored more than one month are used in later evaluations, creation date of the artefacts, number of stored artefacts used and the method of storage must be included with the new evaluation to show proper procedures were followed for handling the artefacts (the method of creation of the stored artefacts does not need to be included).
+
+Before use, the evaluator shall check any stored artefacts for visible changes between the artefact and the subject to determine if the artefact is still acceptable for use. For example, a fingerprint artefact where the subject may have cut on their finger at the time of testing would lead to an artefact not being of sufficient quality. 
+
+However, as artefacts may degrade over time in ways that are not visible to the human eye but which may impact PAD performance, a PAD test must not rely solely on stored artefacts. To ensure that artefacts are not failing solely due to some sort of unseen degradation, if stored artefacts are to be used, a PAD test sequence must utilize a combination of both stored and freshly created artefacts. 
+
+The purpose of this mix is to provide a check that the stored artefacts by comparing the performance of the stored artefacts to the new ones. Stored artefacts that seem to perform significantly lower then they should must be discarded and fresh artefacts created to replace them. The test report must denote which artefacts were stored vs fresh. It is always recommended to create new artefacts for every test to avoid this check if the time and cost of creation of artefacts is low.
+
+As different modalities have different types of artefacts, the modality overview documents specify the requirements for artefact reuse in terms of the maximum percentage of stored artefacts of a type which can be used in testing.
 
 ==== Presentation of artefacts
 The results of the presentation of artefacts is defined as:
@@ -149,7 +216,7 @@ The presentation attack can be performed through the following two steps after p
 ==== Artefact production
 The production of artefacts for each toolbox shall be performed as follows:
 
-* The evaluator shall produce all artefacts defined in the toolbox.
+* The evaluator shall produce artefacts according to the Verification List defined in the toolbox based on the sensor type. If the sensor type does not match one explicitly listed, then all artefacts must be created (as defined by the Other type).
 
 * The evaluator shall follow instructions in the toolbox to produce artefacts, especially the evaluator shall use tools or materials (e.g. camera, display or printer) that meet requirements in toolbox.
 
@@ -217,23 +284,23 @@ The production of artefacts for each toolbox shall be performed as follows:
 
 * The evaluator may refine the production process of artefacts, as explained in <<BIOSD>> Section 7. The toolbox describes generalized process to produce artefacts referring to research papers. These research papers may describe more detailed information to produce better artefacts. Such information is valuable if the TOE's PAD algorithm is the same or similar to ones tested by researchers. The evaluator shall consider relevant research papers to be authoritative over the generalized descriptions provided in a toolbox for improving the creation of artefacts.
 
-* The evaluator may produce an arbitrary number of artefacts from each test subject within allowed time period. As described in <<BIOSD>>, both independent and penetration testing shall be finished within one week.
+* The evaluator may produce an arbitrary number of artefacts from each test subject within allowed time period. As described in <<BIOSD>>, penetration testing shall be finished within one week.
 
 ==== Presentation of artefacts
 The evaluator shall present artefacts to the TOE to perform presentation attacks.
 
-* Each artefact shall be presented to the TOE an arbitrary number of times within allowed time period. As described in <<BIOSD>>, both independent and penetration testing shall be finished within one week.
+* Each artefact shall be presented to the TOE an arbitrary number of times within allowed time period. As described in <<BIOSD>>, penetration testing shall be finished within one week.
 
 === Number of Subjects
 If the evaluator can create artefacts that produce an attack presentation match during independent testing, the evaluator should select the test subjects whose artefacts had successful matches and increase the number of attempts/transactions. The evaluator may replace the test subject for penetration testing as described in <<BIOSD>> Section 7.
 
 === Pass/Fail Criteria
-As described in <<BIOSD>>, both independent and penetration testing shall be finished within one week. The evaluator may select one or two artefacts and perform an arbitrary number of attempts/transactions within this time period. If the evaluator can create artefacts that reproducibly cause the TOE to achieve an IAPAR higher than what is specified in FIA_MBV_EXT.3.1, the TOE fails AVA_VAN.1 evaluation.
+As described in <<BIOSD>>, penetration testing shall be finished within one week. The evaluator may select one or two artefacts and perform an arbitrary number of attempts/transactions within this time period. If the evaluator can create artefacts that reproducibly cause the TOE to achieve an IAPAR higher than what is specified in FIA_MBV_EXT.3.1, the TOE fails AVA_VAN.1 evaluation.
 
 == Related Documents
 
-- [#BIOPP-Module]#[BIOPP-Module]# collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, November 9, 2021, Version 1.1
-- [#BIOSD]#[BIOSD]# Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, November 9, 2021, Version 1.1
+- [#BIOPP-Module]#[BIOPP-Module]# collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, September 12, 2022, Version 1.1
+- [#BIOSD]#[BIOSD]# Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, September 12, 2022, Version 1.1
 
 == Revision History
 
@@ -261,7 +328,7 @@ As described in <<BIOSD>>, both independent and penetration testing shall be fin
 |Public Release
 
 |1.1
-|November 9, 2021
+|September 12, 2022
 |Update based on changes to the PP-Module v1.1
 
 |===


### PR DESCRIPTION
* two editorial fixes (#40)

* Added contribution from other repo

* working

* working

* working

* Update toolbox.adoc

Updated text, added specific number of PAIs to be created in the test (as opposed to having this in individual toolbox tests for consistency)

* Update toolbox.adoc

Editorial corrections

* Update toolbox.adoc

Updated the pass/fail criteria based on @the-fiona comments

* Updates to Eye Toolbox

Added new test list (with sensor applicability).

Modified test sets to add number of species types to be produced (including all variants).

Removed "Other" section as this is now in main toolbox overview.

* added to toolbox.adoc

* Migrated vein to adoc

Created attack subfolder, moved all attacks there. Renamed "general.md" to "vein_PADtesting.adoc"

No content changes (other than changing Variations to "None")

* migrated face to adoc

Moved from TXT files to adoc format, not content change.

Moved files into attacks folder to fit with eye (and PR for vein)

* migrated remaining tests to adoc

I migrated the remaining docs to adoc. I copied the attack potential table to all the tests (without changes except in tests 5 becasue those are largely blank so I put in "?"). I moved the remaining files to make it follow the other toolbox updates.

I moved the inventory document to adoc as well.

* IND to FUN

Edited ATE_IND.1 to ATE_FUN.1

* Update toolbox.adoc

undo the ATE_IND to ATE_FUN back to ATE_IND

* remove TODO line

Remove the TODO line based on discussion on 5/16 to leave it as transactions for vendor flexibility

* Single subject update

Based on the 5/30 call this proposed change is to specify the number of subjects to be used in the creation of PAI.

* changed date

changed date

* fixed internal reference link

Similar problem with reference links as in PP-Module

* Clarification about AVA_VAN

Based on comments from Mary Baisch, this update attempts to clarify that that toolbox is not intended for AVA_VAN but can be used as the basis for those tests with modifications that the evaluator may decide to make.

Also found a misspelling, and added the :icons: font in the header (though I removed the section that specifically needed it).

* Revert "Clarification about AVA_VAN"

This reverts commit 05e5e518485624495437872f62b8a98e240f274d.

* Initial update for PR1

Based on comments by Mary Baisch this is intended to further clarify how the toolbox could be used as a basis for the creation of AVA_VAN tests while not being written for that purpose.

Also fixed a misspelling and added :icons: font line to the header.

* Toolbox Template Example

This is in response to #18 about related to having a standardized template for a toolbox.

There are 4 files in the main folder (here BIO is used to mark the modality, so this should be EYE, FACE, FINGER, etc):

PAD Testing - the description of anything specific to this modality that needs to be documented (in addition to the toolbox overview) along with an introduction to the toolbox.

List - a table list of all the tests and any applicability notes (like these are only relevant with certain types of sensors or other considerations)

Inventory - a list of the inventory that is used in the test, things like paper, printers, camera, the things used to make the PAI

References - external references for any of the attacks (a master list)

Within the main folder there would then be subfoldlers marked with XX_<attack category>_attacks. The XX would be numbering for increasing difficulty (i.e. the lowest level PAI, simplest to create would be 01, the most difficult test would be the top number). The <attack category> would be some sort of title that would provide some clarity as to what the tests will be used as a source for the PAI.

Within each folder then, you would have the files names XX_YY_attack where the XX matches the folder number and YY is the test number.

The List table should match out all the numbers. While I don't have it in here, there is a (Vx) listing for some of the tests, this is when there is a number of variants for the specific test available (so a test with a V1 and V2 would have 2 variants in addition to the "base" test). This could be handled in another way though.

This used the eye tests to fill out the template, but I didn't modify any of the files.

* Revert "Toolbox Template Example"

This reverts commit 8a48e39d92791abbe69b1affc3dc689d23fc1c61.

* Revert "Revert "Toolbox Template Example""

This reverts commit aba98fa3a6ea6f084bfbc3c26dc1c3e1ece85f2f.

* Revert "Revert "Revert "Toolbox Template Example"""

This reverts commit 6e2d60807448c26d10d96da5f563c5a0cdf06e90.

* Revert "Revert "Revert "Revert "Toolbox Template Example""""

This reverts commit 448dbb844bf7dec7aef248f6aaaad29252555138.

* Revert "Revert "Revert "Revert "Revert "Toolbox Template Example"""""

This reverts commit 645dcfa2668b8c47cf375893df17ee553e349a3a.

* Toolbox Template Example

This is in response to #18 about related to having a standardized template for a toolbox.

There are 4 files in the main folder (here BIO is used to mark the modality, so this should be EYE, FACE, FINGER, etc):

PAD Testing - the description of anything specific to this modality that needs to be documented (in addition to the toolbox overview) along with an introduction to the toolbox.

List - a table list of all the tests and any applicability notes (like these are only relevant with certain types of sensors or other considerations)

Inventory - a list of the inventory that is used in the test, things like paper, printers, camera, the things used to make the PAI

References - external references for any of the attacks (a master list)

Within the main folder there would then be subfoldlers marked with XX_<attack category>_attacks. The XX would be numbering for increasing difficulty (i.e. the lowest level PAI, simplest to create would be 01, the most difficult test would be the top number). The <attack category> would be some sort of title that would provide some clarity as to what the tests will be used as a source for the PAI.

Within each folder then, you would have the files names XX_YY_attack where the XX matches the folder number and YY is the test number.

The List table should match out all the numbers. While I don't have it in here, there is a (Vx) listing for some of the tests, this is when there is a number of variants for the specific test available (so a test with a V1 and V2 would have 2 variants in addition to the "base" test). This could be handled in another way though.

This used the eye tests to fill out the template, but I didn't modify any of the files.

* update to 3 subjects

Update to three subjects as noted in #17

* Updated to match new toolbox template

This is an update to match the new toolbox template. No changes were made to the attacks themselves. Previous attack set 01 has been removed as the scan and reprint tests have been removed from Face as well.

* Eye Attack Potential update

Added Attack Potential tables for each attack and each species type for each attack. All calculations show under the 13 limit.

* Update for clarification

This is to close #22 as agreed on the 12/5 call.

* Test procedure update

This is to close #23 related to clarifying the overall testing description.

The table was also updated to follow a more "standard" format.

The PP name was updated to match the current.

* first commit

* Update toolbox.adoc

* Update toolbox.adoc

* Update toolbox.adoc

* Update toolbox.adoc

* Brian toolbox edits

My suggested edits to the changes.

I have edited some text (moved a few things around), did some grammar checking, and edited the tables.

* editorial update by Kai

I updated the overview to fix some inconsistency or mistakes

* research paper authority

One line update to strengthen the use of research papers

* 1st commit

* 2nd commit

* 3rd commit

* 1st commit

* Update and rename 2D-face_attack_1-2.adoc to 2D-face_attack_1_1.adoc

* Update 2D_Face_Toolbox_overview.adoc

* Update 2D-face_attack_1_1.adoc

* Update 2D_Face_Toolbox_Tool_Inventory.adoc

* Update and rename references.adoc to 2D_Face_Toolbox_References.adoc

* Update 2D-face_attack_1_1.adoc

* Update and rename 2D-face_attack_1-3.adoc to 2D-face_attack_1_2.adoc

* Update 2D-face_attack_1_2.adoc

* Update 2D-face_attack_1_1.adoc

* Update and rename 2D-face_attack_2-1.adoc to 2D-face_attack_1_3.adoc

* Update 2D-face_attack_1_1.adoc

* Update 2D-face_attack_1_2.adoc

* Update 2D-face_attack_1_1.adoc

* Update 2D-face_attack_1_2.adoc

* Update 2D-face_attack_1_2.adoc

* Update 2D-face_attack_1_3.adoc

* Update and rename 2D-face_attack_2-2.adoc to 2D-face_attack_2-1.adoc

* Delete attack_1-1.adoc

* Update and rename 2D-face_attack_2-3.adoc to 2D-face_attack_2-2.adoc

* Update and rename 2D-face_attack_2-4.adoc to 2D-face_attack_2-3.adoc

* Delete 2D-face_attack_3-1.adoc

* Delete 2D-face_attack_3-2.adoc

* Delete 2D-face_attack_3-3.adoc

* Delete 2D-face_attack_4-1.adoc

* Delete 2D-face_attack_4-2.adoc

* Delete 2D-face_attack_5-1.adoc

* Delete 2D-face_attack_5-2.adoc

* Update 2D_Face_Toolbox_overview.adoc

* Update 2D_Face_Toolbox_Tool_Inventory.adoc

* Update 2D_Face_Toolbox_Tool_Inventory.adoc

* Rename 2D-face_attack_2-1.adoc to 2D-face_attack_2_1.adoc

* Rename 2D-face_attack_2-2.adoc to 2D-face_attack_2_2.adoc

* Rename 2D-face_attack_2-3.adoc to 2D-face_attack_2_3.adoc

* Create 2D_Face_Verification_List.adoc

* Updated based on NK comments

* Update 2D-face_attack_1_3.adoc

* Update 2D-face_attack_1_1.adoc

* Update 2D-face_attack_1_2.adoc

* Update 2D_Face_Verification_List.adoc

* Delete 2D-face_attack_2_1.adoc

* Delete 2D-face_attack_2_2.adoc

* Delete 2D-face_attack_2_3.adoc

* Update toolbox.adoc

* Update toolbox.adoc

* Update toolbox overview

Change the text as suggested by @woodbe in  #32

* Update 2D-face_attack_1_1.adoc

* Update 2D-face_attack_1_2.adoc

* Update 2D-face_attack_1_3.adoc

* editorial fixes

* 3D face toolbox overview

* move file

* Delete 3D_Face_Toolbox_overview.adoc

* editorial fixes

* Update 3D_Face_Toolbox_overview.adoc

* final update

* editorial update

* editorial update

* Update 2D-face_attack_1_1.adoc

* editorial update

* Create 3D-face_attack_1_1.adoc

* Update 2D_Face_Toolbox_Tool_Inventory.adoc

* Create 3D_Face_Toolbox_Tool_Inventory.adoc

* Create 3D-face_attack_3.adoc

* Create 3D_Face_Verification_List.adoc

* Create 3D_Face_Toolbox_References.adoc

* Updates from Brian

I made several updates here. Most focused on language in the reading to be a little clearer. Some table adjustments were also made to present the tables a little better.

* Update 3D_Face_Toolbox_Tool_Inventory.adoc

* Editorial update for proposed release

This is editorial related to the biometricITC/cPP-biometrics#266 to try to polish the Toolbox for release at the same time.

I added a revision history and changed SD to BIOSD. I also edited the title to match with the rest of the docs.

* Update toolbox.adoc

update based on @n-kai comment to move this to the Toolbox from the SD.

* Removal of old toolboxes

Current face and eye toolboxes have been moved to their own repositories, so these are being deleted.

* Removal of old files

These files are being removed as out of date

* Deleting template for toolbox

This template is now out of date. A new one may need to be created, but probably not right now.

* Update toolbox.adoc

Updates based on MITRE's review.

* Updates for public release

These are focused on updating the dates and versions for all the documents in preparation of public release on May 11, 2020.

* Update toolbox.adoc

Added doctype for proper formatting of PDF output

* Move of vein to own repository

moved all vein to separate repository

* two editorial fixes

Fix the errors in table






* Update toolbox.adoc (#42)

* Update toolbox.adoc (#44)

* update pass fail criteria and editorial fixes (#47)

* update pass fail criteria and editorial fixes

* Update toolbox.adoc



* Update toolbox.adoc



* Update toolbox.adoc






* Changes for publication

Summary of changes:

- version number to v1.1
- date changes

* Revert "Changes for publication"

This reverts commit e7730db16b04ab767cc7389bec158c2f69183afa.

* Changes for publication

Summary of changes:

- version number to v1.1
- date changes

* Adding the modality versioning (#55)

This is to close #biometricITC/cPP-biometrics/378

This adds the documentation in the Toolbox Overview about how to find the toolboxes, how they are versioned, and how to reference them in the conformance claims

* all artefacts (#56)

This adjusts the definition of what needs to be produced to specifically note that the verification list defines which artefacts need to be tested with specific types of sensors.

* Test evidence (#57)

* Test evidence

Adding a section about the visual recording of data since it is not necessary to record (via photos or video) the production and use of each individual artefact.

This is to close #52

* Update toolbox.adoc

This incorporates the new text from @n-kai as well as moving it from section 8 to 5.1.2 as suggested by @gfiumara

* audio updates

added some text for audio. While not part of the current toolboxes, this would lessen the need (and maybe prevent) an update if audio is added as a modality.

* updates for significant steps

updates to resolve points raised in 6/28 call

* remove independent week (#59)

remove one week timeline for independent testing

* lifespan (#58)

* lifespan

Added some text about the lifespan of artefacts, mainly to state that they can be stored according to manufacturer's recommendations to be re-used, but that this must be documented.

This is to close #54

* Update toolbox.adoc

to address comments about ensuring a stored artefact is still acceptable

* Update toolbox.adoc

* update for IAPAR

This adds a reference for IAPAR to the intro

* update for stored artefact check

To resolve stored vs fresh artefact checking.

* Update toolbox.adoc (#60)

* Update toolbox.adoc

* Update toolbox.adoc

Additional updates to the language

* Update toolbox.adoc





* Date update

This is just a date update to match the last commit dates

* date change (#61)

This is updating the doc dates to match up with the PP_MDF release date.